### PR TITLE
Update version to reflect alpha status during new round of PRs

### DIFF
--- a/hardlink.py
+++ b/hardlink.py
@@ -431,7 +431,7 @@ gStats = None
 
 file_hashes = None
 
-VERSION = "0.05 - 2010-01-07 (07-Jan-2010)"
+VERSION = "0.06 alpha - 2018-07-04 (04-Jul-2018)"
 
 
 def main():


### PR DESCRIPTION
While there is a queue of pending merges and development, including
possible option parsing changes, best to change version string to an
interim value until a next release.